### PR TITLE
Add asyncronous execution for post requests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,6 +5,7 @@ version = "0.0.1"
 
 [deps]
 DiffFusion = "be7e520c-a8fa-4f26-8f65-6d6d1049182e"
+Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 JSON3 = "0f8b85d8-7281-11e9-16c2-39a750bddbf1"
 OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"

--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 
 [compat]
-DiffFusion = "0.4"
+DiffFusion = "0.5"
 HTTP = "1"
 JSON3 = "1"
 OrderedCollections = "1"

--- a/src/DiffFusionServer.jl
+++ b/src/DiffFusionServer.jl
@@ -1,6 +1,7 @@
 module DiffFusionServer
 
 using DiffFusion
+using Distributed
 using HTTP
 using JSON3
 using OrderedCollections

--- a/src/server/Config.jl
+++ b/src/server/Config.jl
@@ -1,7 +1,8 @@
 
 const _COPY_OP = "COPY"
 const _BUILD_OP = "BUILD"
-const _OPERATIONS = (_COPY_OP, _BUILD_OP)
+const _BUILD_ASYNC_OP = "BUILD_ASYNC"
+const _OPERATIONS = (_COPY_OP, _BUILD_OP, _BUILD_ASYNC_OP)
 
 const _INFO_END_POINT = "/info"
 const _ALIASES_END_POINT = "/aliases"

--- a/src/server/Errors.jl
+++ b/src/server/Errors.jl
@@ -112,3 +112,13 @@ function _error_bulk_element_list_not_found(elem::Any)
     msg = "Request body element list is not available:\n" * string(elem)
     return HTTP.Response(220, JSON3.write(msg))
 end
+
+"""
+    _error_build_async_fail(alias::AbstractString, e::Exception)
+
+Create an error response for a failing BUILD_ASYNC operation.
+"""
+function _error_build_async_fail(alias::AbstractString, e::Exception)
+    msg = "Cannot create Future object for alias " * alias * ".\n" * string(e)
+    return HTTP.Response(221, JSON3.write(msg))
+end

--- a/test/server/example_async.jl
+++ b/test/server/example_async.jl
@@ -1,0 +1,280 @@
+
+using DiffFusionServer
+using HTTP
+using JSON3
+using OrderedCollections
+using Sockets
+using Test
+
+@testset "Test simulation example via asynchronous posts" begin
+
+    file_name = joinpath(@__DIR__, "../json/model_objects.json")
+    model_json = JSON3.read(read(file_name, String))
+
+    file_name = joinpath(@__DIR__, "../json/instrument_objects.json")
+    instrument_json = JSON3.read(read(file_name, String))
+
+
+    @testset "Test individual build requests" begin
+        router = DiffFusionServer.router().router
+        server = HTTP.serve!(router, Sockets.localhost, DiffFusionServer._DEFAULT_PORT)
+        #
+        for d in model_json
+            headers = [ "op" => "build_async", "alias" => d["alias"], ]
+            resp = HTTP.post(
+                "http://localhost:2024/api/v1/ops",
+                headers,
+                JSON3.write(d),
+            )        
+            println(JSON3.read(resp.body))
+        end
+        #
+        headers = [ "op" => "build_async", "alias" => "swap/EUR6M-USD3M-jIKbhm", ]
+        resp = HTTP.post(
+            "http://localhost:2024/api/v1/ops",
+            headers,
+            JSON3.write(instrument_json),
+        )
+        println(JSON3.read(resp.body))
+        # run simulation
+        json_string = """
+        {
+            "typename" : "DiffFusion.Simulation",
+            "constructor" : "simple_simulation",
+            "model" : "{md/G3}",
+            "ch" : "{ch/STD}",
+            "times" : [ 0.00, 0.25, 0.50, 0.75, 1.00, 1.25, 1.50, 1.75, 2.0 ],
+            "n_paths" : 1024,
+            "kwargs" :
+            {
+                "with_progress_bar" : "{true}",
+                "brownian_increments" : "{SobolBrownianIncrements}"
+            }
+        }
+        """
+        json = JSON3.read(json_string)
+        headers = [ "op" => "build_async", "alias" => "sim/G3-Sobol", ]
+        resp = HTTP.post(
+            "http://localhost:2024/api/v1/ops",
+            headers,
+            JSON3.write(json),
+        )        
+        println(JSON3.read(resp.body))
+        # setup path
+        json_string = """
+        {
+            "typename" : "DiffFusion.Path",
+            "constructor" : "path",
+            "sim" : "{sim/G3-Sobol}",
+            "ts" : [
+                "{yc/USD:SOFR}",
+                "{yc/USD:LIB3M}",
+                "{yc/EUR:ESTR}",
+                "{yc/EUR:XCCY}",
+                "{yc/EUR:EURIBOR6M}",
+                "{yc/GBP:SONIA}",
+                "{yc/GBP:XCCY}",
+                "{pa/USD:SOFR}",
+                "{pa/USD:LIB3M}",
+                "{pa/EUR:ESTR}",
+                "{pa/EUR:EURIBOR6M}",
+                "{pa/GBP:SONIA}",
+                "{pa/EUR-USD}",
+                "{pa/GBP-USD}",
+                "{pa/EUHICP}",
+                "{pa/NIK-FUT}"
+            ],
+            "ctx" : "{ct/STD}",
+            "ip" : "{LinearPathInterpolation}"
+        }
+        """
+        json = JSON3.read(json_string)
+        headers = [ "op" => "build_async", "alias" => "path/G3", ]
+        resp = HTTP.post(
+            "http://localhost:2024/api/v1/ops",
+            headers,
+            JSON3.write(json),
+        )        
+        println(JSON3.read(resp.body))
+        # scenarios
+        json_string = """
+        {
+            "typename" : "DiffFusion.ScenarioCube",
+            "constructor" : "scenarios",
+            "legs" : "{swap/EUR6M-USD3M-jIKbhm}",
+            "times" : [ 0.00, 0.25, 0.50, 0.75, 1.00, 1.25, 1.50, 1.75, 2.0 ],
+            "path" : "{path/G3}",
+            "discount_curve_key" : "nothing"
+        }
+        """
+        json = JSON3.read(json_string)
+        headers = [ "op" => "build_async", "alias" => "cube/EUR6M-USD3M-jIKbhm", ]
+        resp = HTTP.post(
+            "http://localhost:2024/api/v1/ops",
+            headers,
+            JSON3.write(json),
+        )        
+        println(JSON3.read(resp.body))
+        # expected exposure
+        json_string = """
+        {
+            "typename" : "DiffFusion.ScenarioCube",
+            "constructor" : "expected_exposure",
+            "scens" : "{cube/EUR6M-USD3M-jIKbhm}",
+            "gross_leg" : "{false}",
+            "average_paths" : "{true}",
+            "aggregate_legs" : "{true}"
+        }
+        """
+        json = JSON3.read(json_string)
+        headers = [ "op" => "build_async", "alias" => "cube/EUR6M-USD3M-jIKbhm/EE", ]
+        resp = HTTP.post(
+            "http://localhost:2024/api/v1/ops",
+            headers,
+            JSON3.write(json),
+        )        
+        println(JSON3.read(resp.body))
+        #
+        headers = [ "op" => "build", "alias" => "cube/EUR6M-USD3M-jIKbhm/EE", ]
+        resp = HTTP.get(
+            "http://localhost:2024/api/v1/ops",
+            headers,
+        )
+        json = JSON3.read(resp.body)
+        # println(keys(json))
+        # println(json.times)
+        # println(keys(json.X))
+        # println(json.X.typename)
+        # println(json.X.constructor)
+        # println(json.X.dims)
+        @test json.X.dims == [1, 9, 1]
+        # close the server which will stop the HTTP server from listening
+        close(server)
+        @test istaskdone(server.task)
+    end
+    
+
+    @testset "Test bulk build requests" begin
+        router = DiffFusionServer.router().router
+        server = HTTP.serve!(router, Sockets.localhost, DiffFusionServer._DEFAULT_PORT)
+        #
+        headers = [ "op" => "BUILD_ASYNC", ]
+        requests = [
+            [d["alias"], d] for d in model_json
+        ]
+        resp = HTTP.post(
+            "http://localhost:2024/api/v1/bulk",
+            headers,
+            JSON3.write(requests),
+        )
+        for msg in JSON3.read(resp.body)
+            println(msg)
+        end 
+        #
+        headers = [ "op" => "build_async", "alias" => "swap/EUR6M-USD3M-jIKbhm", ]
+        resp = HTTP.post(
+            "http://localhost:2024/api/v1/ops",
+            headers,
+            JSON3.write(instrument_json),
+        )
+        println(JSON3.read(resp.body))
+        #
+        json_string = """
+        [
+        {
+            "typename" : "DiffFusion.Simulation",
+            "constructor" : "simple_simulation",
+            "model" : "{md/G3}",
+            "ch" : "{ch/STD}",
+            "times" : [ 0.00, 0.25, 0.50, 0.75, 1.00, 1.25, 1.50, 1.75, 2.0 ],
+            "n_paths" : 1024,
+            "kwargs" :
+            {
+                "with_progress_bar" : "{true}",
+                "brownian_increments" : "{SobolBrownianIncrements}"
+            }
+        },
+        {
+            "typename" : "DiffFusion.Path",
+            "constructor" : "path",
+            "sim" : "{sim/G3-Sobol}",
+            "ts" : [
+                "{yc/USD:SOFR}",
+                "{yc/USD:LIB3M}",
+                "{yc/EUR:ESTR}",
+                "{yc/EUR:XCCY}",
+                "{yc/EUR:EURIBOR6M}",
+                "{yc/GBP:SONIA}",
+                "{yc/GBP:XCCY}",
+                "{pa/USD:SOFR}",
+                "{pa/USD:LIB3M}",
+                "{pa/EUR:ESTR}",
+                "{pa/EUR:EURIBOR6M}",
+                "{pa/GBP:SONIA}",
+                "{pa/EUR-USD}",
+                "{pa/GBP-USD}",
+                "{pa/EUHICP}",
+                "{pa/NIK-FUT}"
+            ],
+            "ctx" : "{ct/STD}",
+            "ip" : "{LinearPathInterpolation}"
+        },
+        {
+            "typename" : "DiffFusion.ScenarioCube",
+            "constructor" : "scenarios",
+            "legs" : "{swap/EUR6M-USD3M-jIKbhm}",
+            "times" : [ 0.00, 0.25, 0.50, 0.75, 1.00, 1.25, 1.50, 1.75, 2.0 ],
+            "path" : "{path/G3}",
+            "discount_curve_key" : "nothing"
+        },
+        {
+            "typename" : "DiffFusion.ScenarioCube",
+            "constructor" : "expected_exposure",
+            "scens" : "{cube/EUR6M-USD3M-jIKbhm}",
+            "gross_leg" : "{false}",
+            "average_paths" : "{true}",
+            "aggregate_legs" : "{true}"
+        }
+        ]
+        """
+        json = JSON3.read(json_string)
+        alias = [
+            "sim/G3-Sobol",
+            "path/G3",
+            "cube/EUR6M-USD3M-jIKbhm",
+            "cube/EUR6M-USD3M-jIKbhm/EE",
+        ]
+        requests = [
+            [ a, d ] for (a, d) in zip(alias, json)
+        ]
+        headers = [ "op" => "BUILD_ASYNC", ]
+        resp = HTTP.post(
+            "http://localhost:2024/api/v1/bulk",
+            headers,
+            JSON3.write(requests),
+        )
+        for msg in JSON3.read(resp.body)
+            println(msg)
+        end
+        #
+        headers = [ "op" => "build", "alias" => "cube/EUR6M-USD3M-jIKbhm/EE", ]
+        resp = HTTP.get(
+            "http://localhost:2024/api/v1/ops",
+            headers,
+        )
+        json = JSON3.read(resp.body)
+        # println(keys(json))
+        # println(json.times)
+        # println(keys(json.X))
+        # println(json.X.typename)
+        # println(json.X.constructor)
+        # println(json.X.dims)
+        @test json.X.dims == [1, 9, 1]
+        #
+        # close the server which will stop the HTTP server from listening
+        close(server)
+        @test istaskdone(server.task)
+    end
+
+
+end

--- a/test/server/router.jl
+++ b/test/server/router.jl
@@ -172,3 +172,96 @@ end
     close(server)
     @assert istaskdone(server.task)
 end
+
+@testset "Test async build operations." begin
+    router = DiffFusionServer.router().router
+    server = HTTP.serve!(router, Sockets.localhost, DiffFusionServer._DEFAULT_PORT)
+    #
+    headers = [ "op" => "build_async", "alias" => "ts/EUR", ]
+    body = OrderedDict{String, Any}(
+       "typename" => "DiffFusion.FlatForward",
+       "constructor" => "FlatForward",
+        "alias" => "ts/EUR",
+        "rate" => 0.0316,
+    )
+    resp = HTTP.post(
+        "http://localhost:2024/api/v1/ops",
+        headers,
+        JSON3.write(body),
+    )
+    @test JSON3.read(resp.body) == "Store object with alias ts/EUR and type Distributed.Future."
+    #
+    headers = [ "alias" => "ts/EUR", "op" => "build" ]
+    resp = HTTP.get(
+        "http://localhost:2024/api/v1/ops",
+        headers,
+    )
+    @test resp.status == 200
+    res_dict = JSON3.read(resp.body)
+    @test res_dict["typename"] == "DiffFusion.FlatForward"
+    @test res_dict["constructor"] == "FlatForward"
+    @test res_dict["alias"] == "ts/EUR"
+    @test res_dict["rate"] == 0.0316
+    #
+    headers = [ "op" => "build_async",]
+    body = [
+        ["yts/1", OrderedDict{String, Any}(
+            "typename" => "DiffFusion.FlatForward",
+            "constructor" => "FlatForward",
+             "alias" => "ts/EUR",
+             "rate" => 0.01,
+        )],
+        ["yts/2", OrderedDict{String, Any}(
+            "typename" => "DiffFusion.FlatForward",
+            "constructor" => "FlatForward",
+             "alias" => "ts/EUR",
+             "rate" => 0.02,
+        )],
+    ]
+    resp = HTTP.post(
+        "http://localhost:2024/api/v1/bulk",
+        headers,
+        JSON3.write(body),
+    )
+    @test resp.status == 200
+    @test JSON3.read(resp.body) == [
+        "Store object with alias yts/1 and type Distributed.Future.",
+        "Store object with alias yts/2 and type Distributed.Future."
+    ]
+    #
+    headers = [ "op" => "copy",]
+    body = [ "yts/1", "yts/2" ]
+    resp = HTTP.get(
+        "http://localhost:2024/api/v1/bulk",
+        headers,
+        JSON3.write(body),
+    )
+    @test resp.status == 200
+    # println(JSON3.read(resp.body))  # this prints the serialised Future
+    #
+    headers = [ "op" => "build",]
+    body = [ "yts/1", "yts/2" ]
+    resp = HTTP.get(
+        "http://localhost:2024/api/v1/bulk",
+        headers,
+        JSON3.write(body),
+    )
+    @test resp.status == 200
+    # println(JSON3.read(resp.body))
+    # check for expected results
+    res_list = JSON3.read(resp.body)
+    @test length(res_list) == 2
+    @test res_list[1]["typename"] == "DiffFusion.FlatForward"
+    @test res_list[1]["constructor"] == "FlatForward"
+    @test res_list[1]["alias"] == "ts/EUR"
+    @test res_list[1]["rate"] == 0.01
+    @test res_list[2]["typename"] == "DiffFusion.FlatForward"
+    @test res_list[2]["constructor"] == "FlatForward"
+    @test res_list[2]["alias"] == "ts/EUR"
+    @test res_list[2]["rate"] == 0.02
+    #
+    # close the server which will stop the HTTP server from listening
+    close(server)
+    @assert istaskdone(server.task)
+end
+

--- a/test/server/server.jl
+++ b/test/server/server.jl
@@ -6,5 +6,6 @@ using Test
     include("errors.jl")
     include("router.jl")
     include("example.jl")
+    include("example_async.jl")
 
 end


### PR DESCRIPTION
This PR adds functionality to execute post requests asynchronously. This aims at avoiding HTTP timeouts for computationally expensive calculations.

To utilise this functionality start Julia with option '-p 1' (or more workers) and use operation 'BUILD_ASYNC' in HTTP request header.