### PR TITLE
Update dependencies and links for DiffFusion v0.6.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "DiffFusionServer"
 uuid = "117087b2-87f9-4369-a30d-c1fcf58cf77c"
 authors = ["Sebastian Schlenkrich <sebastian.schlenkrich@frame-consult.de> and contributors"]
-version = "0.0.1"
+version = "0.0.6"
 
 [deps]
 DiffFusion = "be7e520c-a8fa-4f26-8f65-6d6d1049182e"
@@ -12,7 +12,7 @@ OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 
 [compat]
-DiffFusion = "0.5"
+DiffFusion = "0.6"
 HTTP = "1"
 JSON3 = "1"
 OrderedCollections = "1"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 [![Coverage](https://codecov.io/gh/frame-consulting/DiffFusionServer.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/frame-consulting/DiffFusionServer.jl)
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/frame-consulting/DiffFusionServer.jl/v0.0.4?labpath=examples)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/frame-consulting/DiffFusionServer.jl/v0.0.6?labpath=examples)
 
 The DiffFusionServer.jl package provides a REST API for the [DiffFusion.jl](https://github.com/frame-consulting/DiffFusion.jl) exposure simulation framework.
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 FROM julia:latest
 
 RUN julia -e 'using Pkg; Pkg.add("ArgParse"); Pkg.add("HTTP"); Pkg.add("Sockets");'
-RUN julia -e 'using Pkg; Pkg.add(url="https://github.com/frame-consulting/DiffFusionServer.jl#v0.0.4");'
+RUN julia -e 'using Pkg; Pkg.add(url="https://github.com/frame-consulting/DiffFusionServer.jl#v0.0.6");'
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -138,6 +138,6 @@ DELETE: [api_path]/[version]/ops/
 
 The usage of the API is illustrated by Python and Julia notebooks in the [`examples` folder](https://github.com/frame-consulting/DiffFusionServer.jl/tree/main/examples).
 
-The notebooks can be run via [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/frame-consulting/DiffFusionServer.jl/v0.0.4?labpath=examples) or locally.
+The notebooks can be run via [![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/frame-consulting/DiffFusionServer.jl/v0.0.6?labpath=examples) or locally.
 
 Additional examples are documented via the test suite.

--- a/examples/README.md
+++ b/examples/README.md
@@ -4,7 +4,7 @@ In this folder we give examples how to use DiffFusionServer.
 
 The examples can be run and on *MyBinder.org*.
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/frame-consulting/DiffFusionServer.jl/v0.0.4?labpath=examples)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/frame-consulting/DiffFusionServer.jl/v0.0.6?labpath=examples)
 
 ## Usage
 


### PR DESCRIPTION
This PR updates the dependencies for DiffFusion v0.6.0 and adds links to DiffFusionServer v0.0.6.

We skip DiffFusionServer v0.0.5 tag to align with DiffFusion version number.