### PR TITLE
Add non-blocking get method

### DIFF
--- a/src/server/Errors.jl
+++ b/src/server/Errors.jl
@@ -132,8 +132,13 @@ function _error_option_not_implemented(option_field::AbstractString, option_valu
     HTTP.Response(222, JSON3.write("Option " * option_field * " with value " * option_value * " is not implemented."))
 end
 
+function _error_future_not_ready(alias::AbstractString)
+    msg = "Future object for alias " * alias * " is not ready."
+    return HTTP.Response(223, JSON3.write(msg))
+end
 
-## Use standard error codes in below error functions
+
+# Use standard error codes in below error functions
 
 """
     _error_server_is_busy()

--- a/src/server/Gets.jl
+++ b/src/server/Gets.jl
@@ -45,8 +45,12 @@ function api_get(
         return _error_operation_not_implemented(op)
     end
     obj = repository[alias]
+    # make sure a Future is ready
+    if op == _BUILD_ASYNC_OP && isa(obj, Future) && !isready(obj)
+        return _error_future_not_ready(alias)
+    end
     local out_obj
-    if op==_BUILD_OP
+    if op in (_BUILD_OP, _BUILD_ASYNC_OP)
         try
             out_obj = DiffFusion.serialise(obj)
         catch e

--- a/test/server/get_asynch.jl
+++ b/test/server/get_asynch.jl
@@ -53,7 +53,7 @@ using Test
                 resp = HTTP.get(endpoint, headers)
             end
             #
-            @test run_time < 0.1
+            @test run_time < 0.5
             @test resp.status == DiffFusionServer._NO_HTTP_ERROR
             @test JSON3.read(resp.body) == "nothing"
         end
@@ -84,7 +84,7 @@ using Test
             end
             #
             println(JSON3.read(resp.body))
-            @test run_time < 0.1
+            @test run_time < 0.5
             @test resp.status == 223
             #
             sleep(1.0)  # make sure Future is ready
@@ -92,7 +92,7 @@ using Test
                 resp = HTTP.get(endpoint, headers)
             end
             #
-            @test run_time < 0.1
+            @test run_time < 0.5
             @test resp.status == DiffFusionServer._NO_HTTP_ERROR
             @test JSON3.read(resp.body) == "nothing"
         end
@@ -108,7 +108,7 @@ using Test
             end
             #
             body = JSON3.read(resp.body)
-            @test run_time < 0.1
+            @test run_time < 0.5
             @test resp.status == DiffFusionServer._NO_HTTP_ERROR
             @test isa(body, JSON3.Object)
             for key in keys(body)

--- a/test/server/get_asynch.jl
+++ b/test/server/get_asynch.jl
@@ -1,0 +1,122 @@
+
+using DiffFusionServer
+using HTTP
+using JSON3
+using OrderedCollections
+using Sockets
+using Test
+
+@testset "Asynchronous get for long-running calculations" begin
+    
+        (router, repository) = DiffFusionServer.router()
+        server = HTTP.serve!(router, Sockets.localhost, DiffFusionServer._DEFAULT_PORT)
+        endpoint = "http://localhost:2024/api/v1/ops"
+        json_string = """
+            {
+                "typename" : "Nothing",
+                "constructor" : "later",
+                "seconds" : 1
+            }
+        """
+
+        @testset "Wait while post on later call" begin
+            #
+            headers = [ "op" => "build", "alias" => "later/build/1", ]
+            run_time = @elapsed begin
+                resp = HTTP.post(endpoint, headers, json_string)
+            end
+            #
+            @test run_time > 1.0
+            @test resp.status == DiffFusionServer._NO_HTTP_ERROR
+            println(JSON3.read(resp.body))
+        end
+
+        @testset "Do not wait while async build on later call" begin
+            #
+            headers = [ "op" => "build_async", "alias" => "later/build_async/1", ]
+            run_time = @elapsed begin
+                resp = HTTP.post(endpoint, headers, json_string)
+            end
+            #
+            @test run_time < 1.0
+            @test resp.status == DiffFusionServer._NO_HTTP_ERROR
+            println(JSON3.read(resp.body))
+        end
+
+        @testset "No need to wait on get" begin
+            #
+            headers = [ "op" => "build", "alias" => "later/build/1", ]
+            resp = HTTP.post(endpoint, headers, json_string)
+            #
+            headers = [ "op" => "build", "alias" => "later/build/1", ]
+            run_time = @elapsed begin
+                resp = HTTP.get(endpoint, headers)
+            end
+            #
+            @test run_time < 0.1
+            @test resp.status == DiffFusionServer._NO_HTTP_ERROR
+            @test JSON3.read(resp.body) == "nothing"
+        end
+
+        @testset "Wait on get for async build" begin
+            #
+            headers = [ "op" => "build_async", "alias" => "later/build_async/1", ]
+            resp = HTTP.post(endpoint, headers, json_string)
+            #
+            headers = [ "op" => "build", "alias" => "later/build_async/1", ]
+            run_time = @elapsed begin
+                resp = HTTP.get(endpoint, headers)
+            end
+            #
+            @test run_time > 1.0
+            @test resp.status == DiffFusionServer._NO_HTTP_ERROR
+            @test JSON3.read(resp.body) == "nothing"
+        end
+
+        @testset "Do not wait on async get for async build" begin
+            #
+            headers = [ "op" => "build_async", "alias" => "later/build_async/1", ]
+            resp = HTTP.post(endpoint, headers, json_string)
+            #
+            headers = [ "op" => "build_async", "alias" => "later/build_async/1", ]
+            run_time = @elapsed begin
+                resp = HTTP.get(endpoint, headers)
+            end
+            #
+            println(JSON3.read(resp.body))
+            @test run_time < 0.1
+            @test resp.status == 223
+            #
+            sleep(1.0)  # make sure Future is ready
+            run_time = @elapsed begin
+                resp = HTTP.get(endpoint, headers)
+            end
+            #
+            @test run_time < 0.1
+            @test resp.status == DiffFusionServer._NO_HTTP_ERROR
+            @test JSON3.read(resp.body) == "nothing"
+        end
+
+        @testset "Do not wait on copy get for async build" begin
+            #
+            headers = [ "op" => "build_async", "alias" => "later/build_async/1", ]
+            resp = HTTP.post(endpoint, headers, json_string)
+            #
+            headers = [ "op" => "copy", "alias" => "later/build_async/1", ]
+            run_time = @elapsed begin
+                resp = HTTP.get(endpoint, headers)
+            end
+            #
+            body = JSON3.read(resp.body)
+            @test run_time < 0.1
+            @test resp.status == DiffFusionServer._NO_HTTP_ERROR
+            @test isa(body, JSON3.Object)
+            for key in keys(body)
+                @test key in (:where, :whence, :id, :lock, :v,)
+            end
+        end
+
+        close(server)
+        @test istaskdone(server.task)
+
+end

--- a/test/server/server.jl
+++ b/test/server/server.jl
@@ -7,5 +7,6 @@ using Test
     include("router.jl")
     include("example.jl")
     include("example_async.jl")
+    include("get_asynch.jl")
 
 end


### PR DESCRIPTION
This PR adds the `build_async` operation to the GET method.

If the requested object is a Future and if it is not (yet) ready then the server returns an error instead of waiting for the object being calculated.